### PR TITLE
Add versioning support to .htaccess

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -1,5 +1,34 @@
 RewriteEngine On
 
+# Extract version from the path: /v1.0.0/
+RewriteCond %{REQUEST_URI} ^/([^/]+)/?(index\.html)?$
+RewriteRule ^([^/]+)/?(index\.html)?$ - [E=VERSION:%1]
+
+# HTML (versioned)
+RewriteCond %{HTTP_ACCEPT} text/html [OR]
+RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://aiaont.github.io/infocomm/infocomm.html?v=%{ENV:VERSION} [R=303,L]
+
+# JSON-LD (versioned)
+RewriteCond %{HTTP_ACCEPT} application/json [OR]
+RewriteCond %{HTTP_ACCEPT} application/ld\+json
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/infocomm@%{ENV:VERSION}/infocomm.jsonld [R=303,L]
+
+# Turtle (versioned)
+RewriteCond %{HTTP_ACCEPT} text/turtle
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/infocomm@%{ENV:VERSION}/infocomm.ttl [R=303,L]
+
+# RDF/XML (versioned)
+RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteCond %{ENV:VERSION} !^$
+RewriteRule ^([^/]+)/?(index\.html)?$ https://cdn.jsdelivr.net/gh/aiaont/infocomm@%{ENV:VERSION}/infocomm.owl [R=303,L]
+
+# Fallback rules for non-versioned requests (root path)
 # HTML
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]


### PR DESCRIPTION
- Implement version extraction from URL paths (e.g., /v1.0.0/)
- Add versioned content negotiation for all formats
- Maintain backward compatibility with non-versioned requests
- Support version-specific resource routing via GitHub tags